### PR TITLE
Fix end turn option not being added to the options list

### DIFF
--- a/csharp/HearthstoneReplays/Parser/Regexes.cs
+++ b/csharp/HearthstoneReplays/Parser/Regexes.cs
@@ -26,7 +26,7 @@ namespace HearthstoneReplays.Parser
 		public static readonly Regex SendChoicesChoicetypeRegex = new Regex(@"id=(\d+) ChoiceType=(.+)$");
 		public static readonly Regex SendChoicesEntitiesRegex = new Regex(@"m_chosenEntities\[(\d+)\]=(\[.+\])$");
 		public static readonly Regex OptionsEntityRegex = new Regex(@"id=(\d+)$");
-		public static readonly Regex OptionsOptionRegex = new Regex(string.Format(@"option (\d+) type=(\w+) mainEntity={0}$", Entity));
+		public static readonly Regex OptionsOptionRegex = new Regex(string.Format(@"option (\d+) type=(\w+) mainEntity={0}?$", Entity));
 		public static readonly Regex OptionsSuboptionRegex = new Regex(string.Format(@"(subOption|target) (\d+) entity={0}?$", Entity));
 
 		public static readonly Regex SendOptionRegex =


### PR DESCRIPTION
This fixes DTD validation errors caused by empty options lists, which occur when ending the turn is the only option. The END_TURN option is added with entity = 0 as demanded by the DTD.
Exemplary log line: `GameState.DebugPrintOptions() -   option 0 type=END_TURN mainEntity=`